### PR TITLE
Add handshake timeout

### DIFF
--- a/__tests__/child.ts
+++ b/__tests__/child.ts
@@ -148,6 +148,23 @@ test('Responds correctly to channel init message', () => {
     );
 });
 
+test('Rejects queued requests after timeout', async () => {
+    client = new ChildClient({
+        requestTimeout: 200
+    });
+
+    let rejected = false;
+
+    await new Promise(resolve => {
+        client.getContext().catch(() => {
+            rejected = true;
+            resolve();
+        });
+    });
+
+    expect(rejected).toBe(true);
+});
+
 test('Resolves requests to `getContext()` after receiving context from child client', async () => {
     client = new ChildClient<ParentContext>();
 

--- a/__tests__/parent.ts
+++ b/__tests__/parent.ts
@@ -163,6 +163,23 @@ test('Sends a channel init message to the provided iframe on client.requestChann
     expect(port2).toEqual(mockMessageChannel.port2);
 });
 
+test('Rejects queued requests after timeout', async () => {
+    const client = new ParentClient({ requestTimeout: 200 });
+
+    client.requestChannel(frame, parentContext);
+
+    let rejected = false;
+
+    await new Promise(resolve => {
+        client.getContext().catch(() => {
+            rejected = true;
+            resolve();
+        });
+    });
+
+    expect(rejected).toBe(true);
+});
+
 test('Resolves requests to `getContext()` after receiving context from child client', async () => {
     const client = new ParentClient<ChildContext>();
 

--- a/src/child.ts
+++ b/src/child.ts
@@ -24,6 +24,8 @@ export class ChildClient<C = any> extends SharedClient<C> {
                 this.profiler.getEvents()
             );
         }
+
+        this.setInitTimer();
     }
 
     protected getLogger() {
@@ -45,6 +47,10 @@ export class ChildClient<C = any> extends SharedClient<C> {
     destroy() {
         if (this.messagePort) {
             this.messagePort.close();
+        }
+
+        if (this.initTimer) {
+            clearTimeout(this.initTimer);
         }
 
         window.removeEventListener('message', this.initListener);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,6 @@ export enum TransactionDirection {
     DOWN = 'down'
 }
 
-export const REQUEST_TIMEOUT = 10000;
+export const REQUEST_TIMEOUT = 20000;
 
 export const REQUEST_KEY_GET_PROFILE = 'framepost_get_profile';

--- a/src/parent.ts
+++ b/src/parent.ts
@@ -29,6 +29,8 @@ export class ParentClient<C = any> extends SharedClient<C> {
 
             this.messagePort.onmessage = this.initListener.bind(this);
 
+            this.setInitTimer();
+
             frame.contentWindow.postMessage(message, this.url.origin, [
                 messageChannel.port2
             ]);
@@ -55,6 +57,10 @@ export class ParentClient<C = any> extends SharedClient<C> {
     destroy() {
         if (this.messagePort) {
             this.messagePort.close();
+        }
+
+        if (this.initTimer) {
+            clearTimeout(this.initTimer);
         }
     }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -186,7 +186,11 @@ export abstract class SharedClient<C> {
     }
 
     protected async messageListener(ev: MessageEvent<Message>) {
-        await this.channel.promise;
+        try {
+            await this.channel.promise;
+        } catch (e) {
+            // if handshake fails, do nothing
+        }
 
         const isValidMessage = this.isValidMessage(ev);
 


### PR DESCRIPTION
* Add timeout to handshake operations in parent and child clients. After handshake, all pending promises will reject
* Increase default request timeout to 20s
* Bugfix: Catch rejections in promise initialized in shared constructor