### PR TITLE
IE 11 / dev server bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,13 @@
     </head>
 
     <body>
-        <div id="wrapper"></div>
+        <div id="wrapper">
+            Bundle is served at
+            <a href="http://localhost:8080/dist/framepost.min.js"
+                >http://localhost:8080/dist/framepost.min.js</a
+            >
+        </div>
 
-        <script src="dist/main.js"></script>
+        <script src="dist/framepost.min.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test:unit": "jest",
         "format": "prettier --write .",
         "sandbox": "node scripts/sandbox.js",
-        "start": "yarn watch & webpack-dev-server --mode development --progress --color --hot",
+        "start": "yarn watch & webpack serve --mode development --progress --color --hot",
         "test": "jest",
         "watch": "webpack --watch --mode development"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
 module.exports = {
+    mode: 'production',
+    target: ['web', 'es5'],
     devtool: 'source-map',
     entry: './src/index.ts',
     output: {


### PR DESCRIPTION
Fixes two bugs:

1. Set webpack target to es5 so that top-level bundling code is IE11 compatible (there was an arrow function in the umd module definition)
1. Fix webpack dev server / yarn start so that it correctly serves code / uses updated `webpack serve` cli command