### PR TITLE
Allow request rejection

### DIFF
--- a/sandbox/child/index.html
+++ b/sandbox/child/index.html
@@ -28,7 +28,7 @@
             client.onRequest('requestFromChild', async () => {
                 await new Promise(res => setTimeout(res, 1000));
 
-                return 'childResponse';
+                throw new Error('hihi');
             });
 
             client.request('requestFromParent').then(data => {

--- a/sandbox/parent/index.html
+++ b/sandbox/parent/index.html
@@ -42,11 +42,14 @@
 
             client.send('down', { data: 'down' });
 
-            client.request('requestFromChild').then(data => {
-                console.log('received requested data from child', data);
-            }).catch(e => {
-                console.log(e);
-            });
+            client
+                .request('requestFromChild')
+                .then(data => {
+                    console.log('received requested data from child', data);
+                })
+                .catch(e => {
+                    console.log(e);
+                });
         </script>
     </body>
 </html>

--- a/sandbox/parent/index.html
+++ b/sandbox/parent/index.html
@@ -44,6 +44,8 @@
 
             client.request('requestFromChild').then(data => {
                 console.log('received requested data from child', data);
+            }).catch(e => {
+                console.log(e);
             });
         </script>
     </body>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum MessageType {
     CHANNEL_INIT = 'channel_init',
     EVENT = 'event',
     REQUEST = 'request',
-    RESPONSE = 'response'
+    RESPONSE = 'response',
+    ERROR_RESPONSE = 'error_response'
 }
 
 export enum MessageAPIVersion {
@@ -17,6 +18,11 @@ export enum ProfileEventType {
 export enum TransactionDirection {
     UP = 'up',
     DOWN = 'down'
+}
+
+export enum SerializationType {
+    NONE = 'none',
+    ERROR = 'error'
 }
 
 export const REQUEST_TIMEOUT = 20000;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Typed errors allow consumer to distinguish failure cases
+ */
+
+export class HandshakeTimeoutError extends Error {
+    constructor() {
+        super('Handshake timed out');
+
+        this.name = 'HandshakeTimeoutError';
+    }
+}
+
+export class RequestTimeoutError extends Error {
+    constructor() {
+        super('Request timed out');
+
+        this.name = 'RequestTimeoutError';
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { ChildClient } from './child';
 export { ParentClient } from './parent';
 
 export * from './types';
+export * from './errors';

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -4,6 +4,7 @@ import {
     REQUEST_TIMEOUT,
     MessageAPIVersion
 } from './constants';
+import { HandshakeTimeoutError, RequestTimeoutError } from './errors';
 import { Logger } from './logger';
 import { Profiler, getProfiler } from './profiler';
 import type {
@@ -142,7 +143,7 @@ export abstract class SharedClient<C> {
 
             timer = setTimeout(() => {
                 unsubscribeResponseHandler();
-                reject('Request timed out');
+                reject(new RequestTimeoutError());
             }, this.requestTimeout);
         });
     }
@@ -291,7 +292,7 @@ export abstract class SharedClient<C> {
 
     protected setInitTimer() {
         this.initTimer = setTimeout(() => {
-            this.channel.reject('Handshake timed out');
+            this.channel.reject(new HandshakeTimeoutError());
             this.destroy();
         }, this.requestTimeout);
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -13,7 +13,7 @@ import type {
     EventHandler,
     RequestHandler
 } from './types';
-import { defer, randomInsecureId, omit } from './utils';
+import { defer, randomInsecureId, omit, serialize, deserialize } from './utils';
 
 export interface SharedClientOptions {
     debug?: boolean;
@@ -131,7 +131,11 @@ export abstract class SharedClient<C> {
 
                 unsubscribeResponseHandler();
 
-                resolve(response);
+                if (message.type === MessageType.ERROR_RESPONSE) {
+                    reject(response);
+                } else {
+                    resolve(response);
+                }
             };
 
             this.responseSubscriptions[sentMessage.id] = responseHandler;
@@ -157,14 +161,26 @@ export abstract class SharedClient<C> {
             requestData: Q,
             requestMessage: Message<Q>
         ) => {
-            const response = await requestHandler(requestData, requestMessage);
+            try {
+                const response = await requestHandler(
+                    requestData,
+                    requestMessage
+                );
 
-            this.postMessage(
-                MessageType.RESPONSE,
-                requestKey,
-                response,
-                requestMessage.id
-            );
+                this.postMessage(
+                    MessageType.RESPONSE,
+                    requestKey,
+                    response,
+                    requestMessage.id
+                );
+            } catch (e) {
+                this.postMessage(
+                    MessageType.ERROR_RESPONSE,
+                    requestKey,
+                    e,
+                    requestMessage.id
+                );
+            }
         };
 
         this.requestSubscriptions[requestKey] = requestEventHandler;
@@ -194,31 +210,32 @@ export abstract class SharedClient<C> {
 
         const isValidMessage = this.isValidMessage(ev);
 
+        const message = deserialize(ev.data);
+
         if (isValidMessage) {
-            switch (ev.data.type) {
+            switch (message.type) {
                 case MessageType.EVENT: {
-                    this.handleEvent(ev);
+                    this.handleEvent(message);
                     break;
                 }
                 case MessageType.REQUEST: {
-                    this.handleRequest(ev);
+                    this.handleRequest(message);
                     break;
                 }
+                case MessageType.ERROR_RESPONSE:
                 case MessageType.RESPONSE: {
-                    this.handleResponse(ev);
+                    this.handleResponse(message);
                     break;
                 }
             }
 
-            this.profiler.logEvent(ProfileEventType.RECEIVE_MESSAGE, ev.data);
+            this.profiler.logEvent(ProfileEventType.RECEIVE_MESSAGE, message);
         } else {
             this.logger.error('Invalid message format. Skipping.');
         }
     }
 
-    protected handleEvent<T = any>(ev: MessageEvent<Message<T>>) {
-        const message = ev.data;
-
+    protected handleEvent<T = any>(message: Message<T>) {
         const subscriptions = this.eventSubscriptions[message.key];
 
         if (subscriptions) {
@@ -228,9 +245,7 @@ export abstract class SharedClient<C> {
         }
     }
 
-    protected handleRequest<Q = any>(ev: MessageEvent<Message<Q>>) {
-        const message = ev.data;
-
+    protected handleRequest<Q = any>(message: Message<Q>) {
         const handler = this.requestSubscriptions[message.key];
 
         if (handler) {
@@ -240,9 +255,7 @@ export abstract class SharedClient<C> {
         }
     }
 
-    protected handleResponse<R = any>(ev: MessageEvent<Message<R>>) {
-        const message = ev.data;
-
+    protected handleResponse<R = any>(message: Message<R>) {
         const requestId = message.requestId;
 
         const handler = requestId && this.responseSubscriptions[requestId];
@@ -260,14 +273,14 @@ export abstract class SharedClient<C> {
     ): Promise<Message<T>> {
         const { port } = await this.channel.promise;
 
-        const message: Message = {
+        const message: Message = serialize({
             type,
             apiVersion: MessageAPIVersion.v1,
             key,
             data,
             id: randomInsecureId(),
             requestId
-        };
+        });
 
         port.postMessage(message);
 
@@ -332,13 +345,13 @@ export abstract class SharedClient<C> {
     }
 
     protected getInitMessage<T = any>(context: T): Message<T> {
-        const message: Message<T> = {
+        const message: Message<T> = serialize({
             type: MessageType.CHANNEL_INIT,
             apiVersion: MessageAPIVersion.v1,
             key: '',
             data: context,
             id: randomInsecureId()
-        };
+        });
 
         return message;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@ import type {
     MessageType,
     MessageAPIVersion,
     ProfileEventType,
-    TransactionDirection
+    TransactionDirection,
+    SerializationType
 } from './constants';
 
 /**
@@ -23,6 +24,7 @@ export interface Message<T = any> {
     apiVersion: MessageAPIVersion;
     key: string;
     data: T;
+    serialization: SerializationType;
     id: string;
     requestId?: string;
 }
@@ -51,6 +53,12 @@ export type RequestHandler<Q = any, R = any> = (
     requestData: Q,
     message: Message<Q>
 ) => R;
+
+export interface SerializedError {
+    name: string;
+    message: string;
+    stack?: string;
+}
 
 /**
  * Profiling metadata about a message


### PR DESCRIPTION
# Changes
1. Support rejection / throwing in request handlers
This allows the consumer to throw an error in a request handler, and for that error to be propagated to the other client:
```
// handler
client.onRequest('my-request', () => {
  ...
  throw new Error('this went wrong');
});

// request will now throw:
client.request('my-request', 'requestData') // will reject with `new Error('this went wrong');`
```

To support this feature, message serialization is added because native errors are not supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

**NOTE** Custom errors (those extending native Error instance) are not supported.
1. Create typed exceptions `HandshakeTimeoutError` and `RequestTimeoutError`. This allows consumer to check what went wrong:
```
import { init, HandshakeTimeoutError } from '@datadog/framepost';

init().catch(e => {
  if (e instanceOf HandshakeTimeoutError) {

  }
})
```

