### PR TITLE
Support popups

### DIFF
--- a/src/parent.ts
+++ b/src/parent.ts
@@ -14,29 +14,43 @@ export class ParentClient<C = any> extends SharedClient<C> {
     }
 
     /**
-     * Request a channel with the child client. Must be called after child
+     * Request a channel with a child client in an iframe. Must be called after child
      * frame is fully loaded.
      */
     requestChannel<T>(frame: HTMLIFrameElement, context: T) {
-        this.url = new URL(frame.src);
-
         if (frame.contentWindow) {
-            const messageChannel = new MessageChannel();
-
-            this.messagePort = messageChannel.port1;
-
-            const message = this.getInitMessage(context);
-
-            this.messagePort.onmessage = this.initListener.bind(this);
-
-            this.setInitTimer();
-
-            frame.contentWindow.postMessage(message, this.url.origin, [
-                messageChannel.port2
-            ]);
-
-            this.profiler.logEvent(ProfileEventType.POST_MESSAGE, message);
+            this.handleRequstChannel<T>(frame.contentWindow, frame.src, context);
         }
+    }
+
+    /**
+     * Request a channel with the child client in a new tab or a new window opened with window.open(). 
+     * Must be called after the popup has fully loaded, if not blocked by a popup blocker.
+     */
+    requestChannelWithPopup<T>(targetWindow: Window, url: string, context: T) {
+        if (targetWindow.opener) {
+            this.handleRequstChannel<T>(targetWindow, url, context);
+        }
+    }
+
+    private handleRequstChannel<T>(targetWindow: Window, url: string, context: T) {
+        this.url = new URL(url);
+
+        const messageChannel = new MessageChannel();
+
+        this.messagePort = messageChannel.port1;
+
+        const message = this.getInitMessage(context);
+
+        this.messagePort.onmessage = this.initListener.bind(this);
+
+        this.setInitTimer();
+
+        targetWindow.postMessage(message, this.url.origin, [
+            messageChannel.port2
+        ]);
+
+        this.profiler.logEvent(ProfileEventType.POST_MESSAGE, message);
     }
 
     async getMessageProfile(): Promise<MessageProfile[]> {

--- a/src/parent.ts
+++ b/src/parent.ts
@@ -19,12 +19,16 @@ export class ParentClient<C = any> extends SharedClient<C> {
      */
     requestChannel<T>(frame: HTMLIFrameElement, context: T) {
         if (frame.contentWindow) {
-            this.handleRequstChannel<T>(frame.contentWindow, frame.src, context);
+            this.handleRequstChannel<T>(
+                frame.contentWindow,
+                frame.src,
+                context
+            );
         }
     }
 
     /**
-     * Request a channel with the child client in a new tab or a new window opened with window.open(). 
+     * Request a channel with the child client in a new tab or a new window opened with window.open().
      * Must be called after the popup has fully loaded, if not blocked by a popup blocker.
      */
     requestChannelWithPopup<T>(targetWindow: Window, url: string, context: T) {
@@ -33,7 +37,11 @@ export class ParentClient<C = any> extends SharedClient<C> {
         }
     }
 
-    private handleRequstChannel<T>(targetWindow: Window, url: string, context: T) {
+    private handleRequstChannel<T>(
+        targetWindow: Window,
+        url: string,
+        context: T
+    ) {
         this.url = new URL(url);
 
         const messageChannel = new MessageChannel();


### PR DESCRIPTION
Add `requestChannelWithPopup()` which allows framepost to work with Window references created by `window.open()`.