### PR TITLE
Error handling bug fixes

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -221,8 +221,9 @@ export abstract class SharedClient<C> {
     /**
      * Rejects if the handshake process has failed
      */
-    async handshake() {
-        await this.channel.promise;
+    async handshake(): Promise<C> {
+        const { context } = await this.channel.promise;
+        return context;
     }
 
     protected async messageListener(ev: MessageEvent<Message>) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import {
     REQUEST_KEY_GET_PROFILE,
     SerializationType
 } from './constants';
+import { HandshakeTimeoutError, RequestTimeoutError } from './errors';
 import type {
     Deferred,
     Message,
@@ -120,10 +121,20 @@ const serializeError = (error: Error): SerializedError => {
 };
 
 const deserializeError = ({ name, message, stack }: SerializedError): Error => {
-    const e = new Error(message);
-    e.name = name;
-    e.stack = stack;
-    return e;
+    switch (name) {
+        case HandshakeTimeoutError.name: {
+            return new HandshakeTimeoutError();
+        }
+        case RequestTimeoutError.name: {
+            return new RequestTimeoutError();
+        }
+        default: {
+            const e = new Error(message);
+            e.name = name;
+            e.stack = stack;
+            return e;
+        }
+    }
 };
 
 export const serialize = (message: Omit<Message, 'serialization'>): Message => {


### PR DESCRIPTION
* Prevent propagation of handshake errors to `client.send()` and `client.getContext()`
* Introduce new `client.handshake()` method which will throw on handshake failure. This can be used when consumer explicitly wants failure on handshake failure
* Serialize errors to typed instances